### PR TITLE
WSE-244 Add dropdown for admins to change their view to match staff permissions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# don't store netids in repo
+src/Constants/authorization.js

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 University of Notre Dame Archives Records Retention Schedule Database Frontend
 
 This project was bootstrapped with [Create React App](https://github.com/facebookincubator/create-react-app).
+
+To get admin view, your netid needs to belong to an admin group or be in the list of ids at `src/Constants/authorization.js`
+
+This list is maintained in AWS. To get the latest list locally, assume role and run the following:
+```
+node ./scripts/buildConfig.js stage=[stage]
+```

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@babel/preset-react": "^7.12.1",
     "@typescript-eslint/eslint-plugin": "^4.6.0",
     "@typescript-eslint/parser": "^4.6.0",
+    "aws-sdk": "^2.797.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",

--- a/scripts/buildConfig.js
+++ b/scripts/buildConfig.js
@@ -1,0 +1,112 @@
+const AWS = require('aws-sdk')
+const util = require('util')
+const exec = util.promisify(require('child_process').exec)
+const fs = require('fs')
+
+const RED = process.env.CI ? '' : '\033[0;31m'
+const GREEN = process.env.CI ? '' : '\033[0;32m'
+const NC = process.env.CI ? '' : '\033[0m' // No Color
+
+const getStage = () => {
+  const data = process.argv[2].split('=')
+  if (data[0] != 'stage') {
+    throw "Stage variable not set. Example: node buildConfig.js stage=dev"
+  }
+
+  return data[1]
+}
+
+const handler = async () => {
+  try {
+    const stage = getStage()
+    let error = false
+
+    const secretsMapping = [
+      {
+        secretPath: `/all/contentful/${stage}`,
+        fields: [
+          {
+            secretKey: 'archivies/admin_departments',
+            configKey: 'fullAccessDepartments',
+            handler: (str) => str.split('","').map(val => val.replace(/"/g, ''))
+          },
+          {
+            secretKey: 'archivies/admin_ids',
+            configKey: 'fullAccessIds',
+            handler: (str) => str.split(','),
+          },
+        ],
+      },
+    ]
+
+    const secretsOutput = {}
+    const secretsManager = new AWS.SecretsManager({ region: 'us-east-1' })
+    for (let i = 0; i < secretsMapping.length; i++) {
+      const mapping = secretsMapping[i]
+
+      // Fetch secrets from AWS
+      let data
+      try {
+        const params = {
+          SecretId: mapping.secretPath,
+        }
+        data = await secretsManager.getSecretValue(params).promise()
+      } catch(err) {
+        console.error(`${RED}Unable to read ${psList[j].name} from parameter store.${NC}`)
+        if (process.env.CI) {
+          console.error(err)
+        }
+        error = true
+      }
+
+      // Now process the individual fields that we have mapped to config values
+      mapping.fields.forEach(fieldMap => {
+        try {
+          const rawValue = JSON.parse(data.SecretString)[fieldMap.secretKey]
+          // Each value can have its own handler function to process the result after it is retrieved,
+          // in case of string manipulations, splitting into an array, etc.
+          secretsOutput[fieldMap.configKey] = (typeof fieldMap.handler === 'function')
+              ? fieldMap.handler(rawValue)
+              : rawValue
+        } catch(err) {
+          console.error(`${RED}Failed to parse value for ${fieldMap.configKey} from ${mapping.secretPath}.${NC}`)
+          if (process.env.CI) {
+            console.error(err)
+          }
+          error = true
+        }
+      })
+    }
+
+    if (error) {
+      process.exit(1)
+    }
+
+    var stream = fs.createWriteStream(`${__dirname}/../src/Constants/authorization.js`);
+    stream.once('open', function(fd) {
+      stream.write(`module.exports = {\n`)
+      Object.keys(secretsOutput).forEach(key => {
+        if (Array.isArray(secretsOutput[key])) {
+          stream.write(`  ${key}: [\n`)
+          secretsOutput[key].forEach(value => {
+            stream.write(`    '${value}',\n`)
+          })
+          stream.write(`  ],\n`)
+        } else {
+          const isBool = ['true', 'false'].includes(secretsOutput[key].trim().toLowerCase())
+          const value = isBool ? (secretsOutput[key].trim().toLowerCase() === 'true') : `'${secretsOutput[key]}'`
+          stream.write(`  ${key}: ${value},\n`)
+        }
+      })
+      stream.write(`}\n`)
+      stream.end()
+    })
+
+    console.log(`${GREEN}Build config complete.${NC}`)
+  } catch (e) {
+    console.error(e)
+    process.exit(1)
+  }
+}
+
+handler()

--- a/scripts/codebuild/build.sh
+++ b/scripts/codebuild/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "---- BUILD ----"
+echo "----- BUILD -----"
 
 # build
 yarn build || { echo "React Build failed" ;exit 1; }

--- a/scripts/codebuild/install.sh
+++ b/scripts/codebuild/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "----- INSTALL -------"
+echo "----- INSTALL -----"
 
 # build the react app
 npm install -g yarn || { echo "Npm install failed" ;exit 1; }

--- a/scripts/codebuild/local.sh
+++ b/scripts/codebuild/local.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+export LOCAL_DEPLOY=true
+
+# provide some friendly defaults so the user does not need to assuming they are deploying a dev build
+export STAGE=${STAGE:="dev"}
+
 ./scripts/codebuild/install.sh || { exit 1; }
 ./scripts/codebuild/pre_build.sh || { exit 1; }
 ./scripts/codebuild/build.sh || { exit 1; }

--- a/scripts/codebuild/post_build.sh
+++ b/scripts/codebuild/post_build.sh
@@ -1,1 +1,13 @@
 #!/bin/bash
+
+echo "----- POST-BUILD -----"
+
+# This isn't really necessary in the pipeline so don't waste time bothering unless it's a local deploy
+# After deploying, it's kind of annoying and confusing if the configuration is not set to dev.
+# Therefore, rebuild dev config if not already using it.
+if [ ${LOCAL_DEPLOY:=false} = true ] && [ $STAGE != 'dev' ]
+then
+  node ./scripts/buildConfig.js stage=dev
+fi
+
+echo -e "\nBuild completed successfully.\n"

--- a/scripts/codebuild/pre_build.sh
+++ b/scripts/codebuild/pre_build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
-# echo "----- Tests ------"
+echo "----- PRE-BUILD -----"
 
-# yarn test-inline || { echo "React Tests Failed"; exit 1; }
+echo -e "\nFetching application configuration..."
+node ./scripts/buildConfig.js stage=$STAGE || { echo "Building config file failed"; exit 1; }

--- a/src/Components/App/Navigation/ViewDropdown/index.js
+++ b/src/Components/App/Navigation/ViewDropdown/index.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { bindActionCreators } from 'redux'
+import { setView } from 'Store/actions/personalActions'
+import './style.css'
+
+const ViewDropdown = (props) => {
+  // Only admins can change their view
+  if (props.role !== 'admin') {
+    return null
+  }
+
+  const onViewChange = (event) => {
+    if (props.role === 'admin') {
+      props.setView(event.target.value)
+    }
+  }
+
+  return (
+    <div className='viewAsDropdown'>
+      <label>
+        <span className='viewAsText'>View As:</span>
+        <select onChange={onViewChange}>
+          <option value='admin'>Admin</option>
+          <option value='staff'>Staff</option>
+        </select>
+      </label>
+    </div>
+  )
+}
+
+const mapStateToProps = (state) => {
+  const { personalReducer } = state
+  return {
+    role: personalReducer.role,
+  }
+}
+
+const mapDispatchToProps = (dispatch) => {
+  return bindActionCreators({ setView }, dispatch)
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ViewDropdown)

--- a/src/Components/App/Navigation/ViewDropdown/style.css
+++ b/src/Components/App/Navigation/ViewDropdown/style.css
@@ -1,0 +1,13 @@
+.viewAsDropdown {
+  display: inline-block;
+}
+
+.viewAsDropdown select {
+  border-radius: 6px;
+  font-size: 1rem;
+  padding: 0.25rem;
+}
+
+.viewAsText {
+  margin-right: 0.5em;
+}

--- a/src/Components/App/Navigation/index.js
+++ b/src/Components/App/Navigation/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Link, NavLink } from 'react-router-dom'
 import { logOut } from 'Store/actions/personalActions'
+import ViewDropdown from './ViewDropdown'
 import './style.css'
 
 const Navigation = () => {
@@ -22,6 +23,7 @@ const Navigation = () => {
         >Search
         </NavLink>
         <span className='right'>
+          <ViewDropdown />
           {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
           <a
             href='#'

--- a/src/Components/RecordTypePage/index.js
+++ b/src/Components/RecordTypePage/index.js
@@ -9,6 +9,7 @@ import * as html2canvas from 'html2canvas'
 import * as jsPDF from 'jspdf'
 import LoadingOverlay from 'react-loading-overlay'
 import PrintFooter from './PrintFooter'
+import { restrictedFields } from 'Constants/fields'
 
 import './style.css'
 
@@ -96,16 +97,21 @@ class RecordTypePage extends Component {
     return (
       <div className='recordTypePage'>
         {!this.state.isPrinting && (
-          <RecordTypeNav
-            currentId={this.props.recordId}
-            recordTypes={this.props.recordList}
-            print={this.print}
-            location={this.props.location}
-          />
+          <React.Fragment>
+            <RecordTypeNav
+              currentId={this.props.recordId}
+              recordTypes={this.props.recordList}
+              print={this.print}
+              location={this.props.location}
+            />
+          </React.Fragment>
         )}
         {(this.state.isPrinting ? this.props.recordList : [this.props.recordType]).map(record => (
           <React.Fragment key={record.sys.id}>
-            <RecordType recordType={record} />
+            <RecordType
+              recordType={record}
+              hideFields={!this.props.isAdminView ? restrictedFields : []}
+            />
             <PrintFooter isSaving={this.state.isPrinting} recordId={record.sys.id} />
           </React.Fragment>
         ))}
@@ -142,6 +148,7 @@ const mapStateToProps = (state, ownProps) => {
     recordList: recordList,
     recordType: recordType,
     instantDownload: searchParams.get('download') === 'true',
+    isAdminView: (state.personalReducer.view || state.personalReducer.role) === 'admin',
   }
 }
 

--- a/src/Components/RecordTypePage/index.js
+++ b/src/Components/RecordTypePage/index.js
@@ -97,14 +97,12 @@ class RecordTypePage extends Component {
     return (
       <div className='recordTypePage'>
         {!this.state.isPrinting && (
-          <React.Fragment>
-            <RecordTypeNav
-              currentId={this.props.recordId}
-              recordTypes={this.props.recordList}
-              print={this.print}
-              location={this.props.location}
-            />
-          </React.Fragment>
+          <RecordTypeNav
+            currentId={this.props.recordId}
+            recordTypes={this.props.recordList}
+            print={this.print}
+            location={this.props.location}
+          />
         )}
         {(this.state.isPrinting ? this.props.recordList : [this.props.recordType]).map(record => (
           <React.Fragment key={record.sys.id}>

--- a/src/Components/Shared/RecordType/index.js
+++ b/src/Components/Shared/RecordType/index.js
@@ -18,7 +18,7 @@ const RecordType = (props) => {
 
   const hiddenFields = displayFields.filter(field => {
     return hideableFields.find(setting => setting.field === field) && !props.recordType.fields[field]
-  })
+  }).concat(props.hideFields)
 
   return (
     <div className='recordType' id={props.recordType.sys.id}>

--- a/src/Constants/authorization.example.js
+++ b/src/Constants/authorization.example.js
@@ -1,0 +1,7 @@
+module.exports = {
+  fullAccessDepartments: ['Office of General Counsel'],
+  fullAccessIds: [
+    'user1_netid',
+    'user2_netid',
+  ],
+}

--- a/src/Constants/fields.js
+++ b/src/Constants/fields.js
@@ -1,3 +1,9 @@
+export const restrictedFields = [
+  'systemOfRecord',
+  'archivesNotes',
+  'generalCounselNotes',
+]
+
 export const displayFields = [
   'recordType',
   'scheduleId',

--- a/src/Global/style.css
+++ b/src/Global/style.css
@@ -57,6 +57,32 @@ mark.term-match {
   clear: both;
 }
 
+.prettyButton {
+  border: 0;
+	border-radius: 2em;
+  color: #FFFFFF;
+	display: inline-block;
+	padding: 0.3em 1.2em;
+	box-sizing: border-box;
+	text-decoration: none;
+	font-family: 'Roboto',sans-serif;
+	font-weight: 300;
+	background-color: #2F5496;
+	text-align: center;
+	transition: all 0.2s;
+}
+.prettyButton:hover {
+	background-color: #4095c6;
+  cursor: pointer;
+}
+
+@media all and (max-width: 30em) {
+ .prettyButton {
+		display: block;
+		margin: 0.2em auto;
+	}
+}
+
 @media screen and (max-width: 780px) {
   .row {
     margin: 0 !important;

--- a/src/Store/actions/personalActions.js
+++ b/src/Store/actions/personalActions.js
@@ -4,9 +4,9 @@ import OktaAuth from '@okta/okta-auth-js'
 // the app to still run for development purposes without any additional setup (e.g. fetching the list from AWS)
 let authorization
 try {
-  authorization = require('Constants/authorization')
+  authorization = require(`Constants/authorization${process.env.CI ? '.example' : ''}`)
 } catch (e) {
-  authorization = require('Constants/authorization.example.js')
+  authorization = require('Constants/authorization.example')
 }
 const { fullAccessIds, fullAccessDepartments } = authorization
 

--- a/src/Store/actions/personalActions.js
+++ b/src/Store/actions/personalActions.js
@@ -1,9 +1,20 @@
 import OktaAuth from '@okta/okta-auth-js'
 
+// Fall back to using the example file if it doesn't exist. This will allow
+// the app to still run for development purposes without any additional setup (e.g. fetching the list from AWS)
+let authorization
+try {
+  authorization = require('Constants/authorization')
+} catch (e) {
+  authorization = require('Constants/authorization.example.js')
+}
+const { fullAccessIds, fullAccessDepartments } = authorization
+
 export const REQUEST_TOKEN = 'REQUEST_TOKEN'
 export const RECEIVE_TOKEN = 'RECEIVE_TOKEN'
 export const RECEIVE_NO_LOGIN = 'RECEIVE_NO_LOGIN'
 export const RECEIVE_VALIDATION_ERROR = 'RECEIVE_VALIDATION_ERROR'
+export const SET_VIEW = 'SET_VIEW'
 
 export const NOT_FETCHED = 'API_STATUS_NOT_FETCHED'
 export const FETCHING = 'API_STATUS_FETCHING'
@@ -49,14 +60,15 @@ export const requestToken = () => {
   }
 }
 
-export const recieveToken = (token) => {
+export const receiveToken = (token, role) => {
   return {
     type: RECEIVE_TOKEN,
     token: token,
+    role: role,
   }
 }
 
-export const recieveNoLogin = () => {
+export const receiveNoLogin = () => {
   return {
     type: RECEIVE_NO_LOGIN,
   }
@@ -69,14 +81,25 @@ export const recieveValidationFailure = (error) => {
   }
 }
 
+export const setView = (view) => {
+  return (dispatch) => dispatch({
+    type: SET_VIEW,
+    view: view,
+  })
+}
+
 const handleToken = (dispatch, data) => {
   if (data.idToken) {
+    let role = 'staff'
+    if (fullAccessDepartments.includes(data.claims.primary_affiliation) || fullAccessIds.includes(data.claims.netid)) {
+      role = 'admin'
+    }
     dispatch(
-      recieveToken(data.idToken),
+      receiveToken(data.idToken, role),
     )
   } else {
     dispatch(
-      recieveNoLogin(),
+      receiveNoLogin(),
     )
   }
 }

--- a/src/Store/reducers/personalReducer.js
+++ b/src/Store/reducers/personalReducer.js
@@ -3,6 +3,7 @@ import {
   RECEIVE_TOKEN,
   RECEIVE_NO_LOGIN,
   RECEIVE_VALIDATION_ERROR,
+  SET_VIEW,
   NOT_FETCHED,
   FETCHING,
   SUCCESS,
@@ -22,6 +23,8 @@ const reducer = (state = { status: NOT_FETCHED, token: null, error: null }, acti
         ...state,
         status: SUCCESS,
         token: action.token,
+        role: action.role,
+        view: action.role,
       }
     case RECEIVE_NO_LOGIN:
       return {
@@ -33,6 +36,11 @@ const reducer = (state = { status: NOT_FETCHED, token: null, error: null }, acti
         ...state,
         status: ERROR,
         error: action.error,
+      }
+    case SET_VIEW:
+      return {
+        ...state,
+        view: action.view,
       }
     default:
       return state

--- a/yarn.lock
+++ b/yarn.lock
@@ -1972,6 +1972,21 @@ autoprefixer@^9.6.1:
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
 
+aws-sdk@^2.797.0:
+  version "2.797.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.797.0.tgz#e9510a582606a580e7bbb686f01da28476599a2d"
+  integrity sha512-fFc/2Xr7NkSXlZ9+2rCOFovA9NO1OnIyEaJFVwMM9gaqzucwRAfNNT0Pa1Kua5dhWrcf/mX0Z4mCDnTBf0/5mA==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -2551,7 +2566,7 @@ buffer-xor@^1.0.3:
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
-buffer@^4.3.0:
+buffer@4.9.2, buffer@^4.3.0:
   version "4.9.2"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
   integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
@@ -4416,6 +4431,11 @@ eventemitter3@^4.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
 events@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.2.0.tgz#93b87c18f8efcd4202a461aec4dfc0556b639379"
@@ -5559,7 +5579,7 @@ icss-utils@^5.0.0:
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.0.0.tgz#03ed56c3accd32f9caaf1752ebf64ef12347bb84"
   integrity sha512-aF2Cf/CkEZrI/vsu5WI/I+akFgdbwQHVE9YRZxATrhH4PVIe6a3BIjwjEcW+z+jP/hNh+YvM3lAAn1wJQ6opSg==
 
-ieee754@^1.1.4:
+ieee754@1.1.13, ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
@@ -6498,6 +6518,11 @@ jest@20.0.4:
   integrity sha1-PdJgwpidba1nix6cxNkZRPbWAqw=
   dependencies:
     jest-cli "^20.0.4"
+
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
 js-cookie@2.2.0:
   version "2.2.0"
@@ -9842,7 +9867,12 @@ sane@~1.6.0:
     walker "~1.0.5"
     watch "~0.10.0"
 
-sax@^1.1.4, sax@^1.2.1, sax@~1.2.4:
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0, sax@^1.1.4, sax@^1.2.1, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -11102,6 +11132,14 @@ url-parse@^1.4.3:
     querystringify "^2.0.0"
     requires-port "^1.0.0"
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -11162,7 +11200,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^3.3.2:
+uuid@3.3.2, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
@@ -11718,6 +11756,19 @@ xhr2@0.1.3:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
   integrity sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=
+
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 xmldom@^0.1.22:
   version "0.1.27"


### PR DESCRIPTION
The front end needs to know if the user is an admin so it can display the UI which lets you select your view. (This way an admin can see what the site looks like for a non-admin.) However, I didn't want to store the list of users in two places: The front-end and the back-end (contentful_direct). So instead I put it in AWS, and use a script in order to build the config file so we can easily get the latest values locally or in a pipeline. This is the same approach usurper uses.

I didn't want to leave a list of netids in the repo though, especially since it gives the impression one can just update the list when the source is actually elsewhere. So I added it to the gitignore, but that also means it can't necessarily be imported because it won't exist when you first pull the repo. To prevent this, it falls back to importing an example file, which lets you skip the pre-requisite step of fetching from AWS altogether if you just want to run the dang thing. :smile: 